### PR TITLE
fix assignment to module.exports

### DIFF
--- a/miniee.js
+++ b/miniee.js
@@ -136,5 +136,5 @@ MiniEventEmitter.mixin	= function(destObject){
 	}
 }
 
-(typeof module != 'undefined') && module.exports = MiniEventEmitter;
+(typeof module != 'undefined') && (module.exports = MiniEventEmitter);
 

--- a/miniee.js
+++ b/miniee.js
@@ -134,7 +134,7 @@ MiniEventEmitter.mixin	= function(destObject){
 	for(var i = 0; i < props.length; i ++){
 		destObject.prototype[props[i]]	= MiniEventEmitter.prototype[props[i]];
 	}
-}
+};
 
 (typeof module != 'undefined') && (module.exports = MiniEventEmitter);
 


### PR DESCRIPTION
first commit fixes the incorrect assignment causing left-hand assignment error.
second commit fixes puts a semicolon after the last function to not let following  parentheses execute it
